### PR TITLE
Handle missing content script when broadcasting timer

### DIFF
--- a/background.js
+++ b/background.js
@@ -33,12 +33,22 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 function broadcastTimer() {
   chrome.tabs.query({}, (tabs) => {
     for (const tab of tabs) {
-      chrome.tabs.sendMessage(tab.id, {
-        type: "updateTimer",
-        timerEnd,
-        remaining,
-        paused,
-      });
+      chrome.tabs.sendMessage(
+        tab.id,
+        {
+          type: "updateTimer",
+          timerEnd,
+          remaining,
+          paused,
+        },
+        () => {
+          // Ignore errors for tabs without the content script
+          if (chrome.runtime.lastError) {
+            // Most likely the tab doesn't have our content script
+            return;
+          }
+        }
+      );
     }
   });
 }


### PR DESCRIPTION
## Summary
- ignore runtime errors when broadcasting timer updates to tabs without the content script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c1bf5b4388333aad9c5e391adc8fb