### PR TITLE
Simpler keyboard timer with background worker

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,85 @@
+let timer = null;
+let intervalId = null;
+
+function broadcast() {
+  chrome.tabs.query({}, (tabs) => {
+    for (const tab of tabs) {
+      chrome.tabs.sendMessage(tab.id, { type: 'timerUpdate', timer });
+    }
+  });
+}
+
+function clearTimer() {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+  timer = null;
+  chrome.storage.local.remove('timer');
+  broadcast();
+}
+
+function tick() {
+  if (!timer || timer.paused) return;
+  const elapsed = Math.floor((Date.now() - timer.start) / 1000);
+  timer.remaining = Math.max(0, timer.duration - elapsed);
+  if (timer.remaining <= 0) {
+    clearTimer();
+  } else {
+    chrome.storage.local.set({ timer });
+    broadcast();
+  }
+}
+
+function startTimer(duration) {
+  timer = {
+    start: Date.now(),
+    duration,
+    remaining: duration,
+    paused: false,
+  };
+  chrome.storage.local.set({ timer });
+  if (intervalId) clearInterval(intervalId);
+  intervalId = setInterval(tick, 1000);
+  broadcast();
+}
+
+function togglePause() {
+  if (!timer) return;
+  if (timer.paused) {
+    timer.start = Date.now() - (timer.duration - timer.remaining) * 1000;
+    timer.paused = false;
+  } else {
+    timer.paused = true;
+  }
+  chrome.storage.local.set({ timer });
+  broadcast();
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'startTimer') {
+    startTimer(msg.duration);
+  } else if (msg.type === 'togglePause') {
+    togglePause();
+  } else if (msg.type === 'getTimer') {
+    sendResponse({ timer });
+  }
+});
+
+// restore timer from storage on startup
+chrome.storage.local.get('timer', ({ timer: saved }) => {
+  if (saved) {
+    timer = saved;
+    const remaining = saved.paused
+      ? saved.remaining
+      : Math.max(0, saved.duration - Math.floor((Date.now() - saved.start) / 1000));
+    timer.remaining = remaining;
+    if (remaining > 0) {
+      if (!saved.paused) intervalId = setInterval(tick, 1000);
+      broadcast();
+    } else {
+      chrome.storage.local.remove('timer');
+      timer = null;
+    }
+  }
+});

--- a/content.js
+++ b/content.js
@@ -1,5 +1,4 @@
 let overlay;
-let intervalId;
 
 function createOverlay() {
   if (!overlay) {
@@ -14,10 +13,6 @@ function removeOverlay() {
     overlay.remove();
     overlay = null;
   }
-  if (intervalId) {
-    clearInterval(intervalId);
-    intervalId = null;
-  }
 }
 
 function formatTime(sec) {
@@ -26,93 +21,33 @@ function formatTime(sec) {
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
-function updateFromStorage() {
-  chrome.storage.local.get('timer', ({ timer }) => {
-    if (!timer) {
-      removeOverlay();
-      return;
-    }
-
-    createOverlay();
-
-    let remaining;
-    if (timer.paused) {
-      remaining = timer.remaining;
-    } else {
-      remaining = Math.max(
-        0,
-        Math.ceil(timer.duration - (Date.now() - timer.start) / 1000)
-      );
-    }
-
-    if (remaining <= 0) {
-      chrome.storage.local.remove('timer');
-      removeOverlay();
-      return;
-    }
-
-    overlay.textContent = formatTime(remaining);
-  });
-}
-
-function ensureInterval() {
-  if (!intervalId) {
-    intervalId = setInterval(updateFromStorage, 1000);
+function updateDisplay(info) {
+  if (!info || info.remaining <= 0) {
+    removeOverlay();
+    return;
   }
+  createOverlay();
+  overlay.textContent = formatTime(info.remaining);
 }
 
-function startTimer(duration) {
-  const timer = {
-    start: Date.now(),
-    duration,
-    paused: false,
-    remaining: duration,
-  };
-  chrome.storage.local.set({ timer });
-}
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'timerUpdate') {
+    updateDisplay(msg.timer);
+  }
+});
 
-function togglePause() {
-  chrome.storage.local.get('timer', ({ timer }) => {
-    if (!timer) return;
-
-    if (timer.paused) {
-      timer.start = Date.now() - (timer.duration - timer.remaining) * 1000;
-      timer.paused = false;
-    } else {
-      timer.remaining = Math.max(
-        0,
-        Math.ceil(timer.duration - (Date.now() - timer.start) / 1000)
-      );
-      timer.paused = true;
-    }
-    chrome.storage.local.set({ timer });
-  });
-}
+chrome.runtime.sendMessage({ type: 'getTimer' }, (response) => {
+  if (response && response.timer) {
+    updateDisplay(response.timer);
+  }
+});
 
 document.addEventListener('keydown', (e) => {
   if (e.key === 'n') {
-    startTimer(10 * 60);
+    chrome.runtime.sendMessage({ type: 'startTimer', duration: 10 * 60 });
   } else if (e.key === 'r') {
-    startTimer(2 * 60);
+    chrome.runtime.sendMessage({ type: 'startTimer', duration: 2 * 60 });
   } else if (e.key === ' ') {
-    togglePause();
-  }
-});
-
-chrome.storage.local.get('timer', ({ timer }) => {
-  if (timer) {
-    updateFromStorage();
-    ensureInterval();
-  }
-});
-
-chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === 'local' && changes.timer) {
-    if (changes.timer.newValue) {
-      updateFromStorage();
-      ensureInterval();
-    } else {
-      removeOverlay();
-    }
+    chrome.runtime.sendMessage({ type: 'togglePause' });
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,8 @@
   "name": "Timer Overlay",
   "version": "1.0",
   "description": "Simple keyboard-controlled timer overlay.",
-  "permissions": ["storage"],
+  "permissions": ["storage", "tabs"],
+  "background": { "service_worker": "background.js" },
   "host_permissions": ["<all_urls>"],
   "content_scripts": [
     {


### PR DESCRIPTION
## Summary
- add a service worker (`background.js`) to manage the timer and broadcast updates
- simplify `content.js` so it only sends commands and shows updates
- register the worker in the manifest and request `tabs` permission

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c2397725083338cd34c617dc01371