### PR TITLE
Add popup UI for timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Timer Overlay Extension
+
+This Chrome extension shows a small timer overlay on every page and provides a
+popup to start or pause the timer.
+
+## Usage
+
+* Press **n** to start a 10 minute timer.
+* Press **r** to start a 2 minute timer.
+* Press **space** to pause/resume the timer.
+
+You can also click the extension icon to open a popup where you can start a
+custom timer by entering minutes and hitting **Start**.

--- a/manifest.json
+++ b/manifest.json
@@ -3,14 +3,31 @@
   "name": "Timer Overlay",
   "version": "1.0",
   "description": "Simple keyboard-controlled timer overlay.",
-  "permissions": ["storage", "tabs"],
-  "background": { "service_worker": "background.js" },
-  "host_permissions": ["<all_urls>"],
+  "permissions": [
+    "storage",
+    "tabs"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
-      "js": ["content.js"],
-      "css": ["overlay.css"]
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "css": [
+        "overlay.css"
+      ]
     }
-  ]
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Timer"
+  }
 }

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { min-width: 200px; font-family: sans-serif; padding: 10px; }
+    #time { font-size: 2em; margin-bottom: 10px; }
+  </style>
+</head>
+<body>
+  <div id="time">0:00</div>
+  <input type="number" id="duration" placeholder="minutes" />
+  <button id="start">Start</button>
+  <button id="pause">Pause/Resume</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,41 @@
+const timeDisplay = document.getElementById('time');
+const durationInput = document.getElementById('duration');
+
+function computeRemaining(info) {
+  if (!info) return 0;
+  if (info.paused) return info.remaining;
+  const elapsed = Math.floor((Date.now() - info.start) / 1000);
+  return Math.max(0, info.duration - elapsed);
+}
+
+function formatTime(sec) {
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function updateTimer() {
+  chrome.runtime.sendMessage({ type: 'getTimer' }, (response) => {
+    const info = response ? response.timer : null;
+    if (info) {
+      const remaining = computeRemaining(info);
+      timeDisplay.textContent = formatTime(remaining);
+    } else {
+      timeDisplay.textContent = '0:00';
+    }
+  });
+}
+
+document.getElementById('start').addEventListener('click', () => {
+  const minutes = parseInt(durationInput.value, 10);
+  if (!isNaN(minutes) && minutes > 0) {
+    chrome.runtime.sendMessage({ type: 'startTimer', duration: minutes * 60 });
+  }
+});
+
+document.getElementById('pause').addEventListener('click', () => {
+  chrome.runtime.sendMessage({ type: 'togglePause' });
+});
+
+setInterval(updateTimer, 1000);
+updateTimer();


### PR DESCRIPTION
## Summary
- add `popup.html` and `popup.js` so clicking the extension icon opens a simple timer UI
- update manifest to include the popup as the default action
- document usage in a new README

## Testing
- `jq . manifest.json`

------
https://chatgpt.com/codex/tasks/task_e_687c26ba07a083338c3d7e526791ddd6