### PR TITLE
Always display timer overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Timer Overlay Extension
 
-This Chrome extension shows a small timer overlay on every page and provides a
-popup to start or pause the timer.
+This Chrome extension shows a small timer overlay on every page at all times.
+Use the provided popup or keyboard shortcuts to start or pause the timer.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- keep the timer overlay visible across all tabs
- remove overlay removal logic and show 0:00 when idle
- document new behavior in README

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687c27e9d2508333a3e0e8f12995a73f