### PR TITLE
Add dropdown timer presets and global hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,25 @@ This project provides a small always-on-top timer application for Windows built 
 ## Usage
 
 1. Ensure Python 3 is installed on your system.
-2. Run the application:
+2. Install the optional `keyboard` library if you want to use global hotkeys:
+   ```bash
+   pip install keyboard
+   ```
+3. Run the application:
    ```bash
    python timer.py
    ```
-3. The window will appear in the top-left corner and remain above other windows.
+4. The window will appear in the top-left corner and remain above other windows.
 
-### Keyboard Controls
+### Using the Timer
 
-- **n** &ndash; start a 5 minute timer
-- **r** &ndash; start a 2 minute timer
-- **space** &ndash; pause/resume the current timer
+Select a time from the drop-down menu and press **Start** to begin the timer.
+You can still use the following hotkeys while the app is focused. If the
+`keyboard` package is installed, these hotkeys will also work globally when the
+app is in the background:
+
+- **n** – start a 5 minute timer
+- **r** – start a 2 minute timer
+- **space** – pause or resume the current timer
 
 A message box is shown when the timer reaches zero.

--- a/timer.py
+++ b/timer.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import messagebox, ttk
 
 class TimerApp:
     def __init__(self, master):
@@ -12,10 +12,33 @@ class TimerApp:
         self.remaining = 0
         self.running = False
 
-        self.label = tk.Label(master, text="00:00", font=('Helvetica', 20))
-        self.label.pack(padx=10, pady=10)
+        self.label = ttk.Label(master, text="00:00", font=('Helvetica', 24))
+        self.label.pack(padx=10, pady=(10, 5))
+
+        # Dropdown to select timer length
+        self.time_var = tk.StringVar(value='5 minutes')
+        self.options = {
+            '2 minutes': 2 * 60,
+            '5 minutes': 5 * 60,
+            '10 minutes': 10 * 60,
+            '15 minutes': 15 * 60,
+        }
+        self.dropdown = ttk.OptionMenu(master, self.time_var, self.time_var.get(), *self.options.keys())
+        self.dropdown.pack(pady=(0, 5))
+
+        self.start_btn = ttk.Button(master, text="Start", command=self.start_selected_time)
+        self.start_btn.pack(pady=(0, 10))
 
         master.bind('<Key>', self.key_handler)
+
+        # Try to register global hotkeys
+        try:
+            import keyboard
+            self._keyboard = keyboard
+            self.register_global_hotkeys()
+        except Exception:
+            # keyboard library not available or failed
+            self._keyboard = None
 
     def key_handler(self, event):
         key = event.keysym.lower()
@@ -25,6 +48,18 @@ class TimerApp:
             self.set_timer(5 * 60)
         elif key == 'r':
             self.set_timer(2 * 60)
+
+    def start_selected_time(self):
+        seconds = self.options.get(self.time_var.get(), 0)
+        if seconds:
+            self.set_timer(seconds)
+
+    def register_global_hotkeys(self):
+        if not self._keyboard:
+            return
+        self._keyboard.add_hotkey('space', self.toggle)
+        self._keyboard.add_hotkey('n', lambda: self.set_timer(5 * 60))
+        self._keyboard.add_hotkey('r', lambda: self.set_timer(2 * 60))
 
     def set_timer(self, seconds):
         self.remaining = seconds


### PR DESCRIPTION
## Summary
- add dropdown and start button UI
- support global hotkeys using the optional `keyboard` library
- document updated usage in README

## Testing
- `python -m py_compile timer.py`


------
https://chatgpt.com/codex/tasks/task_e_687c2bf996b48333adba7d71b4138951