### PR TITLE
Improve global hotkey handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project provides a small always-on-top timer application for Windows built 
    ```bash
    pip install keyboard
    ```
+   On some systems you may need to run the program with administrator/root
+   privileges for the library to capture keys globally.
 3. Run the application:
    ```bash
    python timer.py

--- a/timer.py
+++ b/timer.py
@@ -9,6 +9,9 @@ class TimerApp:
         master.geometry('+0+0')
         master.resizable(False, False)
 
+        # Helper to safely call Tk functions from other threads
+        self._tk_dispatch = lambda func, *a: master.after(0, func, *a)
+
         self.remaining = 0
         self.running = False
 
@@ -36,8 +39,9 @@ class TimerApp:
             import keyboard
             self._keyboard = keyboard
             self.register_global_hotkeys()
-        except Exception:
+        except Exception as e:
             # keyboard library not available or failed
+            print(f"Global hotkeys unavailable: {e}")
             self._keyboard = None
 
     def key_handler(self, event):
@@ -57,9 +61,12 @@ class TimerApp:
     def register_global_hotkeys(self):
         if not self._keyboard:
             return
-        self._keyboard.add_hotkey('space', self.toggle)
-        self._keyboard.add_hotkey('n', lambda: self.set_timer(5 * 60))
-        self._keyboard.add_hotkey('r', lambda: self.set_timer(2 * 60))
+        self._keyboard.add_hotkey('space',
+                                   lambda: self._tk_dispatch(self.toggle))
+        self._keyboard.add_hotkey('n',
+                                   lambda: self._tk_dispatch(self.set_timer, 5 * 60))
+        self._keyboard.add_hotkey('r',
+                                   lambda: self._tk_dispatch(self.set_timer, 2 * 60))
 
     def set_timer(self, seconds):
         self.remaining = seconds


### PR DESCRIPTION
## Summary
- handle keyboard callbacks from a thread-safe helper
- warn when global hotkeys cannot be registered
- document that global hotkeys may require elevated privileges

## Testing
- `python -m py_compile timer.py`


------
https://chatgpt.com/codex/tasks/task_e_687c2d1b6ef88333a09a4e18572e6601